### PR TITLE
Added YAML file for textutil binary

### DIFF
--- a/LOOBins/textutil.yml
+++ b/LOOBins/textutil.yml
@@ -1,0 +1,40 @@
+name: textutil
+author: ezaspy
+short_description: Manipulate text files in various formats.
+full_description: The textutil binary is a command-line utility included in macOS that allows users to manipulate text files of various formats, using the mechanisms provided by the Cocoa text system. Formats include rtf, html, docx
+created: 2023-05-05
+example_use_cases:
+  - name: Use the textutil to read several files and build a new file
+    description: A one-liner can load the content of multiple RTF files in a directory, concatenate their contents, and write the results out as a new file. This provides two sub-use-cases; one is building a malicious file from a collection of smaller files which could evade both network and host-based security controls as the traditional means of signature-based detection would be redundant; two is concatenating the content of several, potentially sensitive files before exfiltration. This command can also be looped to iterate a directory of files.
+    code: textutil -convert html Quote.doc secondQuote.doc
+    tactics:
+      - Defense Evasion
+      - Collection
+    tags:
+      - bash
+      - oneliner
+      - textutil
+  - name: Capture clipboard content
+    description: By leveraging another command line tool, pbpaste, it is possible to write a one-liner which captures to content of the clipboard. If an attacker already has access to the system, the attacker could run this command to obtain sensitive information such as a password and then elevate their privileges or exfiltrate the information.
+    code: pbpaste | textutil -stdin -info > Clipboard.txt
+    tactics:
+      - Credential Access
+      - Collection
+    tags:
+      - bash
+      - oneliner
+      - textutil
+      - pbpaste
+      - clipboard
+paths:
+  - /usr/bin/textutil
+detections:
+  - name: Command Line Argument Detection (args contain textutil AND (-convert OR -stdin OR pbpaste))
+    url: n/a
+resources:
+  - name: textutil
+    url: https://osxdaily.com/tag/textutil/
+  - name: textutil
+    url: https://osxdaily.com/tag/textutil/
+  - name: textutil
+    url: https://osxdaily.com/tag/textutil/


### PR DESCRIPTION
Created YAML file for the textutil binary, containing two use cases. The first is using the textutil to read several files and build a new file, which primarily evades detection. The second is capturing clipboard content and pasting the output using the pbpaste binary, primarily used for Collection or Credential Access.