### PR TITLE
Add "Defense Evasion" to tactics of the Ditto LOOBin

### DIFF
--- a/LOOBins/ditto.yml
+++ b/LOOBins/ditto.yml
@@ -33,6 +33,7 @@ example_use_cases:
   - Collection
   - Exfiltration
   - Lateral Movement
+  - Defense Evasion
   tags:
   - files
 - name: DLL hjiacking


### PR DESCRIPTION
The "Remove extended attributes from a file" use case fits the "Defense Evasion" tactic, so it should be added to that LOOBin.