### PR TITLE
Remove "Privilege Escalation" tactic from "xattr".

### DIFF
--- a/LOOBins/xattr.yml
+++ b/LOOBins/xattr.yml
@@ -19,7 +19,6 @@ example_use_cases:
   code: xattr -d -r com.apple.quarantine *
   tactics:
   - Execution
-  - Privilege Escalation
   - Defense Evasion
   tags:
   - xattr

--- a/LOOBins/xattr.yml
+++ b/LOOBins/xattr.yml
@@ -9,7 +9,6 @@ example_use_cases:
   code: xattr -d com.apple.quarantine FILE
   tactics:
   - Execution
-  - Privilege Escalation
   - Defense Evasion
   tags:
   - xattr


### PR DESCRIPTION
None of the use cases fits in the "Privilege Escalation" tactic.