### PR TITLE
Remove the "Execution" tactic from 4 LOOBins

### DIFF
--- a/LOOBins/dscacheutil.yml
+++ b/LOOBins/dscacheutil.yml
@@ -9,7 +9,6 @@ example_use_cases:
     description: List the user information
     code: dscacheutil -q user -a name <USER_NAME>
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -18,7 +17,6 @@ example_use_cases:
     description: List the all users information
     code: dscacheutil -q user
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash

--- a/LOOBins/dsconfigad.yml
+++ b/LOOBins/dsconfigad.yml
@@ -9,7 +9,6 @@ example_use_cases:
     description: Retrieves the Active Directory configuration
     code: dsconfigad -show
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -18,7 +17,6 @@ example_use_cases:
     description: Retrieves the Active Directory name
     code: dsconfigad -show |awk '/Active Directory Domain/{print $NF}'
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash

--- a/LOOBins/odutil.yml
+++ b/LOOBins/odutil.yml
@@ -8,7 +8,6 @@ example_use_cases:
     description: List all available node names
     code: odutil show nodenames
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -17,7 +16,6 @@ example_use_cases:
     description: Retrieves the all active sessions
     code: odutil show sessions
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -26,7 +24,6 @@ example_use_cases:
     description: Retrieves the configuration of "Default search policy"
     code: odutil show configuration /Search
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -35,7 +32,6 @@ example_use_cases:
     description: Retrieves the configuration of "Contact search policy"
     code: odutil show configuration /Contacts
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash

--- a/LOOBins/system_profiler.yml
+++ b/LOOBins/system_profiler.yml
@@ -8,7 +8,6 @@ example_use_cases:
     description: List all available sub-systems to get information from.
     code: system_profiler -listDataTypes
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -17,7 +16,6 @@ example_use_cases:
     description: Prints an overview of the hardware of the current machine, including its model name and serial number.
     code: system_profiler SPHardwareDataType
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -26,7 +24,6 @@ example_use_cases:
     description: Prints an overview of the software of the current machine, including the exact macOS version number.
     code: system_profiler SPSoftwareDataType
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -35,7 +32,6 @@ example_use_cases:
     description: Prints the currently active version of the Xcode developer tools and SDK.
     code: system_profiler SPDeveloperToolsDataType
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash
@@ -44,7 +40,6 @@ example_use_cases:
     description: Prints power and battery information, including the current AC wattage and battery cycle count.
     code: system_profiler SPPowerDataType
     tactics:
-      - Execution
       - Discovery
     tags:
       - bash


### PR DESCRIPTION
These 4 LOOBins had the "execution" tactic, but it was not really fitting of the tactic:
- dscacheutil
- dsconfigad
- odutil
- system_profiler