### PR TITLE
Change several mentions of reconnaissance to discovery

### DIFF
--- a/LOOBins/GetFileInfo.yml
+++ b/LOOBins/GetFileInfo.yml
@@ -8,7 +8,6 @@ example_use_cases:
     description: A bash or zsh oneliner can provide an attacker with information about specific files of interest.
     code: for FILE in ~/Downloads/*; do echo $(GetFileInfo $FILE) >> fileinfo.txt; sleep 2; done
     tactics:
-      - Reconnaissance
       - Discovery
     tags:
       - bash

--- a/LOOBins/ioreg.yml
+++ b/LOOBins/ioreg.yml
@@ -8,7 +8,7 @@ example_use_cases:
   description: The following command will display a list of keys that contain "CGSSession". If the key "CGSSessionScreenIsLocked" is present, the screen is actively locked.
   code: ioreg -n Root -d1 -a | grep CGSSession
   tactics:
-  - Reconnaissance
+  - Discovery
   tags:
   - bash
   - oneliner
@@ -17,7 +17,7 @@ example_use_cases:
   description: Check the output of this command (specifically the IOPlatformSerialNumber, board-id, and manufacturer fields) to check whether or not this host is in a virtual machine.
   code: ioreg -rd1 -c IOPlatformExpertDevice
   tactics:
-  - Reconnaissance
+  - Discovery
   - Collection
   tags:
   - oneliner
@@ -26,7 +26,7 @@ example_use_cases:
   description: Grep for "USB Vendor Name" values to view USB vendor names. On virtualized hardware these values may contain the hypervisor name such as "VirtualBox". This is an additional way to check for virtualization.  
   code: ioreg -rd1 -c IOUSBHostDevice
   tactics:
-  - Reconnaissance
+  - Discovery
   - Collection
   tags:
   - oneliner
@@ -35,7 +35,7 @@ example_use_cases:
   description: Grep for "virtual box", "oracle", and "vmware" from the output of the ioreg -l command. This is an additional way to check for virtualization.
   code: ioreg -l
   tactics:
-  - Reconnaissance
+  - Discovery
   - Collection
   tags:
   - oneliner

--- a/LOOBins/kextstat.yml
+++ b/LOOBins/kextstat.yml
@@ -4,15 +4,15 @@ short_description: Display the status of loaded kernal extensions (kexts)
 full_description: Deprecated tool in favor of kmutil. Lists loaded kernal extensions
 created: 2023-07-30
 example_use_cases:
-- name: List kernal extensions 
-  description: Uses kmutli showloaded to display kernal extensions and address in kernel memory it has been loaded
+- name: List kernel extensions 
+  description: Uses kexstat showloaded to display kernel extensions and address in kernel memory it has been loaded
   code: kexstat
   tactics:
-  - Reconnaissance
+  - Discovery
   tags:
   - bash
   - zsh
-  - kernal
+  - kernel
 paths:
 - /usr/sbin/kextstat
 detections:

--- a/LOOBins/osascript.yml
+++ b/LOOBins/osascript.yml
@@ -20,7 +20,7 @@ example_use_cases:
     code: osascript -e 'return (system info)'
     tactics:
       - Collection
-      - Reconnaissance
+      - Discovery
     tags:
       - systeminfo
       - oneliner

--- a/LOOBins/sysctl.yml
+++ b/LOOBins/sysctl.yml
@@ -8,7 +8,7 @@ example_use_cases:
   description: sysctl can be used to gather interesting macOS host data, including hardware information, memory size, logical cpu information, etc.
   code: sysctl -n hw.model
   tactics:
-  - Reconnaissance
+  - Discovery
   tags:
   - bash
   - oneliner


### PR DESCRIPTION
It's a common mistake to use the reconnaissance tactic instead of discovery, but in most cases the correct tactic is discovery.