### PR TITLE
Change dscl

### DIFF
--- a/LOOBins/dscl.yml
+++ b/LOOBins/dscl.yml
@@ -9,6 +9,7 @@ example_use_cases:
     code: |
       dscl . -list /Users
       dscl . list /Users
+      dscl . ls /Users
     tactics:
       - Discovery
     tags:
@@ -18,6 +19,7 @@ example_use_cases:
     code: |
       dscl "/Active Directory/TEST/All Domains" -list /Users
       dscl "/Active Directory/TEST/All Domains" list /Users
+      dscl "/Active Directory/TEST/All Domains" ls /Users
     tactics:
       - Discovery
     tags:
@@ -28,6 +30,7 @@ example_use_cases:
     code: |
       dscl . -read /Users/$USERNAME
       dscl . read /Users/$USERNAME
+      dscl . cat /Users/$USERNAME
     tactics:
     - Discovery
     tags:
@@ -38,6 +41,7 @@ example_use_cases:
     code: |
       dscl "/Active Directory/TEST/All Domains" -read /Users/$USERNAME
       dscl "/Active Directory/TEST/All Domains" read /Users/$USERNAME
+      dscl "/Active Directory/TEST/All Domains" cat /Users/$USERNAME
     tactics:
     - Discovery
     tags:
@@ -49,6 +53,7 @@ example_use_cases:
     code: |
       dscl . -list /Groups
       dscl . list /Groups
+      dscl . ls /Groups
     tactics:
     - Discovery
     tags:
@@ -58,6 +63,7 @@ example_use_cases:
     code: |
       dscl "/Active Directory/TEST/All Domains" -list /Groups
       dscl "/Active Directory/TEST/All Domains" list /Groups
+      dscl "/Active Directory/TEST/All Domains" ls /Groups
     tactics:
     - Discovery
     tags:
@@ -68,6 +74,7 @@ example_use_cases:
     code: |
       dscl . -read /Groups/$GROUPNAME
       dscl . read /Groups/$GROUPNAME
+      dscl . cat /Groups/$GROUPNAME
     tactics:
     - Discovery
     tags:
@@ -78,6 +85,7 @@ example_use_cases:
     code: |
       dscl "/Active Directory/TEST/All Domains" -read /Groups/$GROUPNAME
       dscl "/Active Directory/TEST/All Domains" read /Groups/$GROUPNAME
+      dscl "/Active Directory/TEST/All Domains" cat /Groups/$GROUPNAME
     tactics:
     - Discovery
     tags:
@@ -89,6 +97,7 @@ example_use_cases:
     code: |
       dscl  "/Active Directory/TEST/All Domains" -list /Computers
       dscl  "/Active Directory/TEST/All Domains" list /Computers
+      dscl  "/Active Directory/TEST/All Domains" ls /Computers
     tactics:
     - Discovery
     tags:
@@ -99,6 +108,7 @@ example_use_cases:
     code: |
       dscl . -list /SharePoints
       dscl . list /SharePoints
+      dscl . ls /SharePoints
     tactics:
     - Discovery
     tags:
@@ -109,6 +119,7 @@ example_use_cases:
     code: |
       dscl . -read /Config/shadowhash
       dscl . read /Config/shadowhash
+      dscl . cat /Config/shadowhash
     tactics:
     - Discovery
     tags:

--- a/LOOBins/dscl.yml
+++ b/LOOBins/dscl.yml
@@ -6,14 +6,18 @@ created: 2023-04-25
 example_use_cases:
   - name: Local user enumeration
     description: Enumerate all local users.
-    code: dscl . -list /Users
+    code: |
+      dscl . -list /Users
+      dscl . list /Users
     tactics:
       - Discovery
     tags:
       - users
   - name: Active Directory user enumeration
     description: Enumerate all Active Directory users.
-    code: dscl "/Active Directory/TEST/All Domains" -list /Users
+    code: |
+      dscl "/Active Directory/TEST/All Domains" -list /Users
+      dscl "/Active Directory/TEST/All Domains" list /Users
     tactics:
       - Discovery
     tags:
@@ -21,7 +25,9 @@ example_use_cases:
       - users
   - name: Local user information gathering
     description: Gain useful local user information such as when their password was last set, their keyboard layout, their avatar, their home directory, UID and default shell.
-    code: dscl . -read /Users/$USERNAME
+    code: |
+      dscl . -read /Users/$USERNAME
+      dscl . read /Users/$USERNAME
     tactics:
     - Discovery
     tags:
@@ -29,7 +35,9 @@ example_use_cases:
     - configuration
   - name: Active Directory user information gathering
     description: Gain useful Active Directory user information such as when their password was last set, their keyboard layout, their avatar, their home directory, UID and default shell.
-    code: dscl "/Active Directory/TEST/All Domains" -read /Users/$USERNAME
+    code: |
+      dscl "/Active Directory/TEST/All Domains" -read /Users/$USERNAME
+      dscl "/Active Directory/TEST/All Domains" read /Users/$USERNAME
     tactics:
     - Discovery
     tags:
@@ -38,14 +46,18 @@ example_use_cases:
     - configuration
   - name: Local group enumeration
     description: Enumerate all local groups.
-    code: dscl . -list /Groups
+    code: |
+      dscl . -list /Groups
+      dscl . list /Groups
     tactics:
     - Discovery
     tags:
     - groups
   - name: Active Directory group enumeration
     description: Enumerate all Active Directory groups.
-    code: dscl "/Active Directory/TEST/All Domains" -list /Groups
+    code: |
+      dscl "/Active Directory/TEST/All Domains" -list /Groups
+      dscl "/Active Directory/TEST/All Domains" list /Groups
     tactics:
     - Discovery
     tags:
@@ -53,7 +65,9 @@ example_use_cases:
     - groups
   - name: Local group information gathering
     description: Gain useful local group information such as which users belong to that group, SMB SIDs and group ID. Especially useful for the "admin" group.
-    code: dscl . -read /Groups/$GROUPNAME
+    code: |
+      dscl . -read /Groups/$GROUPNAME
+      dscl . read /Groups/$GROUPNAME
     tactics:
     - Discovery
     tags:
@@ -61,7 +75,9 @@ example_use_cases:
     - configuration
   - name: Active Directory group information gathering
     description: Gain useful Active Directory group information such as which users belong to that group, SMB SIDs and group ID. Especially useful for the "admin" group.
-    code: dscl "/Active Directory/TEST/All Domains" -read /Groups/$GROUPNAME
+    code: |
+      dscl "/Active Directory/TEST/All Domains" -read /Groups/$GROUPNAME
+      dscl "/Active Directory/TEST/All Domains" read /Groups/$GROUPNAME
     tactics:
     - Discovery
     tags:
@@ -70,7 +86,9 @@ example_use_cases:
     - configuration
   - name: Computer enumration
     description: Enumerate all computers in an Active Directory.
-    code: dscl  "/Active Directory/TEST/All Domains" -list /Computers
+    code: |
+      dscl  "/Active Directory/TEST/All Domains" -list /Computers
+      dscl  "/Active Directory/TEST/All Domains" list /Computers
     tactics:
     - Discovery
     tags:
@@ -78,7 +96,9 @@ example_use_cases:
     - shares
   - name: Share enumration
     description: Enumerate all shares.
-    code: dscl . -list /SharePoints
+    code: |
+      dscl . -list /SharePoints
+      dscl . list /SharePoints
     tactics:
     - Discovery
     tags:
@@ -86,7 +106,9 @@ example_use_cases:
     - shares
   - name: Password policy discovery
     description: Gain password policy information
-    code: dscl . -read /Config/shadowhash
+    code: |
+      dscl . -read /Config/shadowhash
+      dscl . read /Config/shadowhash
     tactics:
     - Discovery
     tags:


### PR DESCRIPTION
Clarify examples by showing that the -read and -list arguments can be used without the `-`.
Also add aliases (`ls` for `list` and `cat` for `read`) to `dscl`