### PR TITLE
Updated dscacheutil with 2 new use cases, fix descriptions of previous use cases

### DIFF
--- a/LOOBins/dscacheutil.yml
+++ b/LOOBins/dscacheutil.yml
@@ -7,7 +7,7 @@ full_description: |-
 created: 2023-08-23
 example_use_cases:
   - name: Lookup  a user
-    description: List the user information
+    description: List the user information for <USER_NAME>
     code: dscacheutil -q user -a name <USER_NAME>
     tactics:
       - Discovery
@@ -15,8 +15,24 @@ example_use_cases:
       - bash
       - zsh
   - name: Lookup all users
-    description: List the all users information
+    description: List all the users information
     code: dscacheutil -q user
+    tactics:
+      - Discovery
+    tags:
+      - bash
+      - zsh
+  - name: Lookup a group
+    description: List the group information for <GROUP_NAME>
+    code: dscacheutil -q group -a name <GROUP_NAME>
+    tactics:
+      - Discovery
+    tags:
+      - bash
+      - zsh
+  - name: Lookup all groups
+    description: List all the groups information
+    code: dscacheutil -q group
     tactics:
       - Discovery
     tags:
@@ -32,3 +48,7 @@ resources:
     url: https://macosbin.com/bin/dscacheutil
   - name: "dscacheutil man page"
     url: https://ss64.com/osx/dscacheutil.html
+  - name: "MITRE ATT&CK: T1069.002 Permission Groups Discovery: Domain Groups"
+    url: https://attack.mitre.org/techniques/T1069/002/
+  - name: "MITRE ATT&CK: T1087.002 Account Discovery: Domain Account"
+    url: https://attack.mitre.org/techniques/T1087/002/


### PR DESCRIPTION
I updated the dscacheutil binary with 2 new uses cases. The idea comes from two mitre MITRE ATT&CK subtechniques:
- https://attack.mitre.org/techniques/T1087/002/
- https://attack.mitre.org/techniques/T1069/002/

I mentioned these links in the Resources section.

I kept the format as in the previous version (for the users), so I included one use case for a single group and one use case for all the groups.

In addition, I fixed the description of the "lookup a user" use case with a format that I believe is more clear and specific and I fixed the description of the use case "lookup all users" because it contained a typo.
