### PR TITLE
New use cases for launchctl, dscl, csrutil

### DIFF
--- a/LOOBins/csrutil.yml
+++ b/LOOBins/csrutil.yml
@@ -33,6 +33,11 @@ example_use_cases:
       - Discovery
     tags:
       - configuration
+  - name: Determine if SIP is enabled
+    description: Determine if System Integrity Protection is enabled
+    code: csrutil status
+    tactics:
+      - Discovery
 paths:
   - /usr/bin/csrutil
 detections:
@@ -41,3 +46,7 @@ detections:
 resources:
   - name: "Discussion on how SIP interacts with bless and netboot"
     url: https://developer.apple.com/forums/thread/4002
+  - name: "MITRE ATT&CK T1518.001 Software Discovery: Security Software Discovery"
+    url: https://attack.mitre.org/techniques/T1518/001/
+  - name: "The XCSSET Malware: Inserts Malicious Code Into Xcode Projects, Performs UXSSBackdoor Planting in Safari, and LeveragesTwo Zero-day Exploits"
+    url: https://documents.trendmicro.com/assets/pdf/XCSSET_Technical_Brief.pdf

--- a/LOOBins/dscl.yml
+++ b/LOOBins/dscl.yml
@@ -132,6 +132,11 @@ example_use_cases:
     - Persistence
     tags:
     - password
+  - name: Local account creation
+    description: Create a local account
+    code: dscl -create
+    tactics:
+    - Persistence  
 paths:
   - /usr/bin/dscl
 detections:
@@ -140,3 +145,5 @@ detections:
 resources:
   - name: 'MacOS Red Teaming - HackTricks'
     url: https://book.hacktricks.xyz/macos-hardening/macos-security-and-privilege-escalation/macos-red-teaming
+  - name: 'MITRE ATT&CK T1136.001 Create Account: Local Account'
+    url: https://attack.mitre.org/techniques/T1136/001/

--- a/LOOBins/launchctl.yml
+++ b/LOOBins/launchctl.yml
@@ -31,5 +31,5 @@ resources:
   url: https://attack.mitre.org/techniques/T1569/001/
 - name: 'MITRE ATT&CK T1543.001  Create or Modify System Process: Launch Agent '
   url: https://attack.mitre.org/techniques/T1543/001/
-- name: 'Sofacy’s ‘Komplex’ OS X Trojan'
+- name: 'Komplex OS X Trojan (Sofacy)'
   url: https://unit42.paloaltonetworks.com/unit42-sofacys-komplex-os-x-trojan/

--- a/LOOBins/launchctl.yml
+++ b/LOOBins/launchctl.yml
@@ -32,4 +32,4 @@ resources:
 - name: 'MITRE ATT&CK T1543.001  Create or Modify System Process: Launch Agent '
   url: https://attack.mitre.org/techniques/T1543/001/
 - name: 'Sofacy’s ‘Komplex’ OS X Trojan'
-	url: https://unit42.paloaltonetworks.com/unit42-sofacys-komplex-os-x-trojan/
+  url: https://unit42.paloaltonetworks.com/unit42-sofacys-komplex-os-x-trojan/

--- a/LOOBins/launchctl.yml
+++ b/LOOBins/launchctl.yml
@@ -14,6 +14,11 @@ example_use_cases:
   - bash
   - zsh
   - oneliner
+- name: Persistent launch agent 
+  description: Creation of a persistent launch agent called with $HOME/Library/LaunchAgents/com.apple.updates.plist
+  code: launchctl load -w ~/Library/LaunchAgents/com.apple.updates.plist
+  tactics:
+  - Persistence
 paths:
 - /bin/launchctl
 detections:
@@ -24,5 +29,7 @@ resources:
   url: https://www.sentinelone.com/labs/20-common-tools-techniques-used-by-macos-threat-actors-malware/
 - name: 'Mitre Attack Technique: launchctl T1569'
   url: https://attack.mitre.org/techniques/T1569/001/
-
-
+- name: 'MITRE ATT&CK T1543.001  Create or Modify System Process: Launch Agent '
+  url: https://attack.mitre.org/techniques/T1543/001/
+- name: 'Sofacy’s ‘Komplex’ OS X Trojan'
+	url: https://unit42.paloaltonetworks.com/unit42-sofacys-komplex-os-x-trojan/


### PR DESCRIPTION
Hello, I have included other use cases for 3 binaries:
- Determine if SIP is enabled for `csrutil` => MITRE ATT&CK T1518.001
- Local account creation for `dscl` => MITRE ATT&CK T1136.001
- Persistent launch agent for `launchctl` => MITRE ATT&CK T1543.001

