### PR TITLE
fix: Broken links to Check Point research

### DIFF
--- a/LOOBins/ioreg.yml
+++ b/LOOBins/ioreg.yml
@@ -47,6 +47,6 @@ detections:
   url: https://github.com/SigmaHQ/sigma/blob/master/rules/macos/process_creation/proc_creation_macos_ioreg_discovery.yml
 resources:
   - name: 'Evasions: macOS'
-    url: https://evasions.checkpoint.com/techniques/macos.html
+    url: https://evasions.checkpoint.com/src/MacOS/macos.html
   - name: 'SwiftBelt-JXA Situational Awareness Tool'
     url: https://github.com/cedowens/SwiftBelt-JXA/blob/main/SwiftBelt-JXA.js#520

--- a/LOOBins/sysctl.yml
+++ b/LOOBins/sysctl.yml
@@ -20,4 +20,4 @@ detections:
   url: N/A
 resources:
 - name: 'Evasions: macOS'
-  url: https://evasions.checkpoint.com/techniques/macos.html
+  url: https://evasions.checkpoint.com/src/MacOS/macos.html


### PR DESCRIPTION
Links in a few pages are currently broken, looks like Check Point changed the URI for evasion techniques.