### PR TITLE
Fix typos and grammar issues in YAML files

### DIFF
--- a/LOOBins/ditto.yml
+++ b/LOOBins/ditto.yml
@@ -36,7 +36,7 @@ example_use_cases:
   - Defense Evasion
   tags:
   - files
-- name: DLL hjiacking
+- name: DLL hijacking
   description: Replace a legitimate library with a malicious one while maintaining the original file permissions and attributes.
   code: ditto -V /path/to/malicious-library/malicious_library.dylib /path/to/target-library/original_library.dylib
   tactics:

--- a/LOOBins/dscacheutil.yml
+++ b/LOOBins/dscacheutil.yml
@@ -15,7 +15,7 @@ example_use_cases:
       - bash
       - zsh
   - name: Lookup all users
-    description: List the all users information
+    description: List all user information
     code: dscacheutil -q user
     tactics:
       - Discovery

--- a/LOOBins/dscl.yml
+++ b/LOOBins/dscl.yml
@@ -92,7 +92,7 @@ example_use_cases:
     - network
     - groups
     - configuration
-  - name: Computer enumration
+  - name: Computer enumeration
     description: Enumerate all computers in an Active Directory.
     code: |
       dscl  "/Active Directory/TEST/All Domains" -list /Computers
@@ -103,7 +103,7 @@ example_use_cases:
     tags:
     - network
     - shares
-  - name: Share enumration
+  - name: Share enumeration
     description: Enumerate all shares.
     code: |
       dscl . -list /SharePoints

--- a/LOOBins/hdiutil.yml
+++ b/LOOBins/hdiutil.yml
@@ -5,7 +5,7 @@ full_description: hdiutil manipulates disk images such as DMG and ISO files. You
 created: 2023-05-21
 example_use_cases:
 - name: Mount a malicious dmg file
-  description: Uses hdiutil to mount a malicious dmg file to 
+  description: Uses hdiutil to mount a malicious dmg file to the system.
   code: hdiutil mount malicious.dmg
   tactics:
   - Execution
@@ -14,7 +14,7 @@ example_use_cases:
   - zsh
   - disk
 - name: Mount a malicious dmg file
-  description: Uses hdiutil to mount a malicious dmg file to 
+  description: Uses hdiutil to mount a malicious dmg file to the system.
   code: hdiutil attach malicious.dmg
   tactics:
   - Execution
@@ -23,7 +23,7 @@ example_use_cases:
   - zsh
   - disk
 - name: Mount a malicious iso file
-  description: Uses hdiutil to mount a malicious iso file to 
+  description: Uses hdiutil to mount a malicious iso file to the system.
   code: hdiutil mount malicious.iso
   tactics:
   - Execution
@@ -32,7 +32,7 @@ example_use_cases:
   - zsh
   - disk
 - name: Mount a malicious iso file
-  description: Uses hdiutil to mount a malicious iso file to 
+  description: Uses hdiutil to mount a malicious iso file to the system.
   code: hdiutil attach malicious.iso
   tactics:
   - Execution

--- a/LOOBins/kextstat.yml
+++ b/LOOBins/kextstat.yml
@@ -1,7 +1,7 @@
 name: kextstat
 author: Mark Morowczynsk (@markmorow)
-short_description: Display the status of loaded kernal extensions (kexts)
-full_description: Deprecated tool in favor of kmutil. Lists loaded kernal extensions
+short_description: Display the status of loaded kernel extensions (kexts)
+full_description: Deprecated tool in favor of kmutil. Lists loaded kernel extensions
 created: 2023-07-30
 example_use_cases:
 - name: List kernel extensions 
@@ -17,7 +17,7 @@ paths:
 - /usr/sbin/kextstat
 detections:
 - name: No detections at time of publishing
-  url: n/a
+  url: N/A
 resources:
 - name: 'kextstat man page'
   url: https://ss64.com/osx/kextstat.html

--- a/LOOBins/log.yml
+++ b/LOOBins/log.yml
@@ -1,7 +1,7 @@
 name: log
 author: Brendan Chamberlain (@infosecB)
 short_description: Access system log messages from Apple Unified Logging (AUL).
-full_description: The log command can be used to access system log messages from Apple Unified Logging (AUL). The tool can be used to inspect exiting logs, stream logs in realtime, and delete logs. This tool is normally used by system admins and application developers for troubleshooting purposes but can be used by an adversary to gain an understanding of the user's behavior or to cover up their tracks by deleting log messages.
+full_description: The log command can be used to access system log messages from Apple Unified Logging (AUL). The tool can be used to inspect existing logs, stream logs in realtime, and delete logs. This tool is normally used by system admins and application developers for troubleshooting purposes but can be used by an adversary to gain an understanding of the user's behavior or to cover up their tracks by deleting log messages.
 created: 2023-06-06
 example_use_cases:
 - name: Remove all log messages

--- a/LOOBins/networksetup.yml
+++ b/LOOBins/networksetup.yml
@@ -1,7 +1,7 @@
 name: networksetup
 author: Jason Trost (@jason_trost)
 short_description: Configure network settings in System Preferences.
-full_description: networksetup extensive tool for reading and setting various network configuration details useful for Discovery and Command and Control.
+full_description: networksetup is an extensive tool for reading and setting various network configuration details useful for Discovery and Command and Control.
 created: 2023-04-22
 example_use_cases:
   - name: network device enumeration

--- a/LOOBins/odutil.yml
+++ b/LOOBins/odutil.yml
@@ -13,7 +13,7 @@ example_use_cases:
       - bash
       - zsh
   - name: Retrieves active session
-    description: Retrieves the all active sessions
+    description: Retrieves all active sessions
     code: odutil show sessions
     tactics:
       - Discovery

--- a/LOOBins/open.yml
+++ b/LOOBins/open.yml
@@ -1,5 +1,5 @@
 name: open
-author: Brendan Chamberlain (@infosecb)
+author: Brendan Chamberlain (@infosecB)
 short_description: Open files, folders, apps, URLs, and header files.
 full_description: The open command-line utility can be used to open files, folders, app, URLs or header files in their associate macOS app.
 created: 2023-05-10

--- a/LOOBins/pbpaste.yml
+++ b/LOOBins/pbpaste.yml
@@ -5,7 +5,7 @@ full_description: Retrieves the contents of the clipboard (a.k.a. pasteboard) an
 created: 2023-04-11
 example_use_cases:
 - name: Use pbpaste to collect sensitive clipboard data
-  description: A pbpaste bash loop can continously collect clipboard contents every x minutes and write contents to a file (or another location). This may allow an attacker to gather user credentials or collect other sensitive information.
+  description: A pbpaste bash loop can continuously collect clipboard contents every x minutes and write contents to a file (or another location). This may allow an attacker to gather user credentials or collect other sensitive information.
   code: while true; do echo $(pbpaste) >> loot.txt; sleep 10; done
   tactics:
   - Credential Access

--- a/LOOBins/plutil.yml
+++ b/LOOBins/plutil.yml
@@ -5,7 +5,7 @@ full_description: plutil is a command-line utility used for managing property li
 created: 2023-05-07
 example_use_cases:
 - name: Set app to run with dock icon hidden
-  description: plutil can be used to set the "LSUIElement" attribute to tue which will force the targeted app to run without the UI and dock icon.
+  description: plutil can be used to set the "LSUIElement" attribute to true which will force the targeted app to run without the UI and dock icon.
   code: >-
     plutil -insert LSUIElement -string "1" /Applications/TargetApp.app/Contents/Info.plist
   tactics:

--- a/LOOBins/screencapture.yml
+++ b/LOOBins/screencapture.yml
@@ -1,10 +1,10 @@
 name: screencapture
 author: Brendan Chamberlain (@infosecB)
 short_description: Capture a screenshot from command line.
-full_description: A tools that allows users to take screenshots of their desktop or specific app windows. The tool can be used by malicious actors to collect sensitve information from the targeted system.
+full_description: A tools that allows users to take screenshots of their desktop or specific app windows. The tool can be used by malicious actors to collect sensitive information from the targeted system.
 created: 2023-04-27
 example_use_cases:
-- name: Continously capture screenshots
+- name: Continuously capture screenshots
   description: The following command demonstrates how an attacker can use the tool to capture screenshots every 10 seconds. The -x flag prevents snapshot sounds from being played.
   code: while true; do ts=$(date +"%Y%m%d-%H%M%S"); o="/tmp/screenshots"; screencapture -x "$o/ss-$ts.png"; sleep 10; done
   tactics:

--- a/LOOBins/security.yml
+++ b/LOOBins/security.yml
@@ -1,10 +1,10 @@
 name: security
-author: Pratik Jeware (@Pratik-987), Brendan Chamberlain (@infosecb)
+author: Pratik Jeware (@Pratik-987), Brendan Chamberlain (@infosecB)
 short_description: Interact with Keychain, macOS's built-in password manager.
 full_description: security is a command-line utility included in macOS that allows users to interact with the Keychain app. Keychains allow users to manager passwords and credentials for many services and features, including Wi-Fi and website passwords, secure notes, certificates, and Kerberos.
 created: 2023-04-24
 example_use_cases:
-  - name: Dump credentials, keys, certificates, and other senstive information from Keychain
+  - name: Dump credentials, keys, certificates, and other sensitive information from Keychain
     description: This command will dump keychain passwords from login.keychain
     code: sudo security dump-keychain -d login.keychain
     tactics:

--- a/LOOBins/tclsh.yml
+++ b/LOOBins/tclsh.yml
@@ -1,7 +1,7 @@
 name: tclsh
 author: Brendan Chamberlain (@infosecB)
 short_description: Run Tcl files or shell commands from standard input.
-full_description: tclsh is a shell-like utility that runs Tcl from standard input or a file. tclsh holds the "com.apple.security.cs.disable-library-validation" entitlement and is capable of loading arbitary plug-ins, framework, and libraries without requiring signed code.
+full_description: tclsh is a shell-like utility that runs Tcl from standard input or a file. tclsh holds the "com.apple.security.cs.disable-library-validation" entitlement and is capable of loading arbitrary plug-ins, framework, and libraries without requiring signed code.
 created: 2023-05-17
 example_use_cases:
 - name: Execute malicious dynamic library (.dylib) from standard input

--- a/LOOBins/textutil.yml
+++ b/LOOBins/textutil.yml
@@ -30,7 +30,7 @@ paths:
   - /usr/bin/textutil
 detections:
   - name: Command Line Argument Detection (args contain textutil AND (-convert OR -stdin OR pbpaste))
-    url: n/a
+    url: N/A
 resources:
   - name: textutil
     url: https://osxdaily.com/tag/textutil/

--- a/LOOBins/tmutil.yml
+++ b/LOOBins/tmutil.yml
@@ -1,5 +1,5 @@
 name: tmutil
-author: Brendan Chamberlain (@infosecb)
+author: Brendan Chamberlain (@infosecB)
 short_description: Manage Time Machine backups.
 full_description: A tool for managing Time Machine, the native macOS backup utility. 
 created: 2023-05-01
@@ -12,7 +12,7 @@ example_use_cases:
   tags:
   - backup
 - name: Delete a backup
-  description: The following command deletes the specified backup. An adversary may perform this action before launching a ransonware attack to prevent the victim from restoring their files.
+  description: The following command deletes the specified backup. An adversary may perform this action before launching a ransomware attack to prevent the victim from restoring their files.
   code: tmutil delete /path/to/backup
   tactics:
   - Impact

--- a/LOOBins/xattr.yml
+++ b/LOOBins/xattr.yml
@@ -5,7 +5,7 @@ full_description: The xattr command can be used to display, modify or remove the
 created: 2023-04-20
 example_use_cases:
 - name: Bypass Gatekeeper via xattr
-  description: Use xattr to remove quaratine extended attribute from a file.
+  description: Use xattr to remove quarantine extended attribute from a file.
   code: xattr -d com.apple.quarantine FILE
   tactics:
   - Execution
@@ -14,7 +14,7 @@ example_use_cases:
   - xattr
   - quarantine
 - name: Bypass Gatekeeper via xattr
-  description: Use xattr to remove quaratine extended attribute from multiple files or directories.
+  description: Use xattr to remove quarantine extended attribute from multiple files or directories.
   code: xattr -d -r com.apple.quarantine *
   tactics:
   - Execution


### PR DESCRIPTION
Fixed 27 issues across 17 YAML files including:
- Spelling errors: hijacking, enumeration, kernel, continuously, true, sensitive, arbitrary, ransomware, quarantine
- Grammar errors: missing articles and verbs
- Incomplete sentences in hdiutil.yml descriptions
- Inconsistent capitalization in author names and N/A values