### PR TITLE
Migrate Python package management from Poetry to uv

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,18 +18,14 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python - -y
-
-      - name: Update PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
-        run: poetry install
+        run: uv sync --group dev
 
       - name: Run Tox
-        run: poetry run tox
+        run: uv run tox
 
   release:
     name: Release to PyPI
@@ -50,23 +46,21 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python - -y
-
-      - name: Update PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Bump patch version
         id: version
         run: |
-          poetry version patch
-          NEW_VERSION=$(poetry version --short)
+          CURRENT_VERSION=$(uv run python -c "import importlib.metadata; print(importlib.metadata.version('PyLOOBins'))" 2>/dev/null || grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+          NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+          sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
       - name: Build project for distribution
-        run: poetry build
+        run: uv build
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
@@ -84,8 +78,8 @@ jobs:
 
       - name: Publish to PyPI
         env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-        run: poetry publish
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish
 
       - name: Configure Git
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -155,8 +155,8 @@ cython_debug/
 # Visual Studio Code
 .vscode/
 
-# Poetry
-poetry.lock
+# uv
+uv.lock
 
 # macOS
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,39 +18,39 @@ LOOBins (Living Off the Orchard: macOS Binaries) is a cybersecurity resource tha
 
 ### Python Development (PyLOOBins SDK)
 ```bash
-# Install dependencies with Poetry
-poetry install
+# Install dependencies with uv
+uv sync --group dev
 
 # Run all tests
-poetry run pytest
+uv run pytest
 
 # Run specific test file
-poetry run pytest tests/test_data.py
-poetry run pytest tests/test_models.py -v
+uv run pytest tests/test_data.py
+uv run pytest tests/test_models.py -v
 
 # Lint and format code
-poetry run black src/
-poetry run isort src/ --profile black
-poetry run pylint src/pyloobins/
+uv run black src/
+uv run isort src/ --profile black
+uv run pylint src/pyloobins/
 
 # Run pre-commit hooks
 pre-commit run --all-files
 
 # Validate LOOBin YAML files
-poetry run pyloobins validate --path LOOBins/example.yml
+uv run pyloobins validate --path LOOBins/example.yml
 
 # Create new LOOBin template
-poetry run pyloobins create --name "BinaryName"
-poetry run pyloobins create --name "BinaryName" --path LOOBins/
+uv run pyloobins create --name "BinaryName"
+uv run pyloobins create --name "BinaryName" --path LOOBins/
 
 # Get LOOBin data as JSON
-poetry run pyloobins get --name "osascript"
+uv run pyloobins get --name "osascript"
 
 # Export STIX bundle (--path controls output directory, not input)
-poetry run pyloobins export-stix --file-name loobins_stix.json --path .
+uv run pyloobins export-stix --file-name loobins_stix.json --path .
 
 # Run multi-version tests with tox (Python 3.8–3.12)
-poetry run tox
+uv run tox
 ```
 
 ## LOOBin YAML Schema
@@ -104,7 +104,7 @@ Each LOOBin must follow the schema defined in `/docs/schema.md`:
 ### Validation Pipeline
 
 - **CI/CD**: `.github/workflows/validate_loobins.yml` validates changed YAML files on PRs (uses `pip install pyloobins` from PyPI, not local source)
-- **Auto-release**: `.github/workflows/auto-release.yml` on push to `main` — runs tox, bumps patch version, builds, publishes to PyPI, creates GitHub release, commits version bump with `[skip ci]`
+- **Auto-release**: `.github/workflows/auto-release.yml` on push to `main` — runs tox via uv, bumps patch version, builds with `uv build`, publishes to PyPI with `uv publish`, creates GitHub release, commits version bump with `[skip ci]`
 - **Pre-commit hooks**: `check-yaml`, `check-toml`, `end-of-file-fixer`, `mixed-line-ending`, `black`, `isort --profile black` (note: pylint is not a pre-commit hook, run it separately)
 - **Schema validation**: Pydantic models ensure YAML files match schema
 - **VS Code integration**: SchemaStore provides YAML validation in VS Code (requires YAML extension)
@@ -114,8 +114,8 @@ Each LOOBin must follow the schema defined in `/docs/schema.md`:
 - **`create --path` requires a trailing slash**: The CLI concatenates path and filename directly (`f"{file_path}{file_name}.yml"`), so use `LOOBins/` not `LOOBins`
 - **`export-stix --path` is output-only**: The `--path` flag controls where the STIX JSON file is written; input LOOBins are always loaded via auto-discovery (`get_loobins()` with no args)
 - **Detection URLs can be `"N/A"`**: The `loobin.md.j2` template handles `"N/A"` as a sentinel value, rendering detections without a link
-- **`polyfactory` is a production dependency**: Listed under `[tool.poetry.dependencies]` but only used in tests (`tests/test_data.py`)
-- **`poetry.lock` is not committed**: Gitignored per library convention — dependency resolution happens at install time
+- **`polyfactory` is a production dependency**: Listed under `[project.dependencies]` but only used in tests (`tests/test_data.py`)
+- **`uv.lock` is not committed**: Gitignored per library convention — dependency resolution happens at install time
 
 ## Contributing Guidelines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,40 +1,50 @@
-[tool.poetry]
+[project]
 name = "PyLOOBins"
 version = "2.0.8"
 description = "Python package for managing the LOOBins model and schema."
-authors = ["infosecB <brendan@infosecb.com>", "0xv1n <0xv1n@protonmail.com>"]
+authors = [
+    { name = "infosecB", email = "brendan@infosecb.com" },
+    { name = "0xv1n", email = "0xv1n@protonmail.com" },
+]
 readme = "docs/pyloobins/README.md"
-packages = [{ include = "pyloobins", from = "src" }]
-include = ["LOOBins/*.yml"]
-homepage = "https://loobins.io/"
-repository = "https://github.com/infosecB/LOOBins"
-keywords = ["cybersecurity", "cli", "lol"]
 license = "GPL-3.0-or-later"
+requires-python = ">=3.8"
+keywords = ["cybersecurity", "cli", "lol"]
+dependencies = [
+    "pydantic>=2,<3",
+    "pyyaml>=6.0,<7",
+    "click>=8.1.3,<9",
+    "jinja2>=3.1.2,<4",
+    "stix2>=3.0.1,<4",
+    "polyfactory>=2.18.0,<3",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-pydantic = "^2"
-pyyaml = "^6.0"
-click = "^8.1.3"
-jinja2 = "^3.1.2"
-stix2 = "^3.0.1"
-polyfactory = "^2.18.0"
+[project.urls]
+Homepage = "https://loobins.io/"
+Repository = "https://github.com/infosecB/LOOBins"
 
+[project.scripts]
+pyloobins = "pyloobins.cli:cli"
 
-[tool.poetry.group.dev.dependencies]
-pylint = "^2.17.0"
-black = "^23.1.0"
-pre-commit = "^3.2.2"
-pytest = "^7.3.1"
-tox = "^4.5.1"
-isort = "^5.12.0"
-
-[tool.poetry.scripts]
-pyloobins = 'pyloobins.cli:cli'
+[dependency-groups]
+dev = [
+    "pylint>=2.17.0",
+    "black>=23.1.0",
+    "pre-commit>=3.2.2",
+    "pytest>=7.3.1",
+    "tox>=4.5.1",
+    "isort>=5.12.0",
+]
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/pyloobins"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src/pyloobins", "LOOBins/*.yml"]
 
 [tool.pylint.'MESSAGES CONTROL']
 disable = ['no-name-in-module', 'too-few-public-methods']


### PR DESCRIPTION
Replace Poetry with uv for faster dependency resolution and simpler PEP 621 compliance. Converts pyproject.toml to standard [project] format with hatchling build backend, updates CI workflows to use astral-sh/setup-uv, and updates all documentation.