### PR TITLE
Fix search dropdown styling and script loading

### DIFF
--- a/web/src/components/SearchWidget.astro
+++ b/web/src/components/SearchWidget.astro
@@ -1,5 +1,7 @@
 ---
 import { url } from '../utils/helpers';
+const cssUrl = url('/pagefind/pagefind-ui.css');
+const jsUrl = url('/pagefind/pagefind-ui.js');
 ---
 
 <div id="search-container" class="relative" data-pagefind-ignore>
@@ -19,33 +21,82 @@ import { url } from '../utils/helpers';
     --pagefind-ui-font: inherit;
   }
 
-  .pagefind-ui .pagefind-ui__search-input {
+  #search-container {
+    position: relative;
+  }
+
+  #search-container .pagefind-ui__search-input {
     background: #0f172a;
     color: #f1f5f9;
+    width: 200px;
+  }
+
+  #search-container .pagefind-ui__drawer {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    width: 500px;
+    max-height: 70vh;
+    overflow-y: auto;
+    background: #1e293b;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+    z-index: 100;
+    padding: 16px;
+  }
+
+  .pagefind-ui .pagefind-ui__results-area {
+    margin-top: 0;
+  }
+
+  .pagefind-ui .pagefind-ui__result {
+    background: #1e293b;
+    border-bottom: 1px solid #334155;
+    padding: 16px 12px;
+  }
+
+  .pagefind-ui .pagefind-ui__result:hover {
+    background: #334155;
+    border-radius: 6px;
   }
 
   .pagefind-ui .pagefind-ui__result-link {
     color: #22c55e;
   }
 
+  .pagefind-ui .pagefind-ui__result-title {
+    color: #f1f5f9;
+  }
+
   .pagefind-ui .pagefind-ui__result-excerpt {
     color: #94a3b8;
   }
+
+  .pagefind-ui .pagefind-ui__message {
+    color: #94a3b8;
+  }
+
+  .pagefind-ui .pagefind-ui__button {
+    background: #334155;
+    color: #f1f5f9;
+  }
+
+  .pagefind-ui .pagefind-ui__button:hover {
+    background: #475569;
+  }
 </style>
 
-<script is:inline>
-  window.addEventListener('DOMContentLoaded', () => {
+<link href={cssUrl} rel="stylesheet" />
+<script is:inline define:vars={{ jsUrl }}>
+  const s = document.createElement('script');
+  s.src = jsUrl;
+  s.onload = () => {
     new PagefindUI({
       element: '#pagefind-search',
       showSubResults: false,
       showImages: false,
     });
-  });
-</script>
-
-<link href={url('/pagefind/pagefind-ui.css')} rel="stylesheet" />
-<script is:inline define:vars={{ pagefindUrl: url('/pagefind/pagefind-ui.js') }}>
-  const s = document.createElement('script');
-  s.src = pagefindUrl;
+  };
   document.head.appendChild(s);
 </script>


### PR DESCRIPTION
## Summary
- Positions search results as an absolute dropdown with a solid dark background, border, and shadow
- Fixes race condition where `PagefindUI` was called before `pagefind-ui.js` finished loading
- Adds proper padding, hover states, and colors for results, messages, and buttons

## Test plan
- [ ] Run `cd web && npm run build && npm run preview`
- [ ] Type in the search bar and verify results appear in a readable dropdown
- [ ] Verify dropdown doesn't bleed through with transparent background

🤖 Generated with [Claude Code](https://claude.com/claude-code)