### PR TITLE
Scope auto-release to LOOBin and SDK changes only

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'LOOBins/**'
+      - 'src/**'
+      - 'pyproject.toml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Adds `paths` filter to the auto-release workflow so it only triggers on changes to `LOOBins/**`, `src/**`, or `pyproject.toml`
- Prevents unnecessary PyPI releases when only `web/` or other non-SDK files change

## Test plan
- [ ] Merge a web-only change to main and verify the release workflow does not run
- [ ] Merge a LOOBin YAML change and verify the release workflow still triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)