### PR TITLE
Add SEO improvements to Astro web UI

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,11 +1,12 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://infosecb.github.io',
   base: '/LOOBins',
-  integrations: [],
+  integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.2",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.4",
         "astro": "^6.2.0",
@@ -74,6 +75,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2083,6 +2095,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2119,6 +2149,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4957,6 +4993,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -4987,6 +5042,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -5149,6 +5210,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.2",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.4",
     "astro": "^6.2.0",

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://infosecb.github.io/LOOBins/sitemap-index.xml

--- a/web/src/layouts/BaseLayout.astro
+++ b/web/src/layouts/BaseLayout.astro
@@ -7,9 +7,13 @@ import '../styles/global.css';
 interface Props {
   title: string;
   description?: string;
+  type?: string;
 }
 
-const { title, description = 'LOOBins - Living Off the Orchard: macOS Binaries' } = Astro.props;
+const { title, description = 'LOOBins - Living Off the Orchard: macOS Binaries', type = 'website' } = Astro.props;
+const fullTitle = `${title} | LOOBins`;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const ogImage = new URL(url('/loobins.png'), Astro.site);
 ---
 
 <!doctype html>
@@ -18,8 +22,34 @@ const { title, description = 'LOOBins - Living Off the Orchard: macOS Binaries' 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
-    <title>{title} | LOOBins</title>
+    <link rel="canonical" href={canonicalURL} />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content={type} />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:title" content={fullTitle} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:site_name" content="LOOBins" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={fullTitle} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+
+    <title>{fullTitle}</title>
     <link rel="icon" type="image/png" href={url('/loobins.png')} />
+    <link rel="apple-touch-icon" href={url('/loobins.png')} />
+
+    <!-- Structured Data -->
+    <script type="application/ld+json" set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "LOOBins",
+      "url": new URL(url('/'), Astro.site).href,
+      "description": "Living Off the Orchard: macOS Binaries - A curated list of macOS built-in binaries that can be used by threat actors for post-exploitation activities.",
+    })} />
   </head>
   <body class="bg-surface text-text-primary min-h-screen flex flex-col">
     <Navbar />

--- a/web/src/pages/binaries/[slug].astro
+++ b/web/src/pages/binaries/[slug].astro
@@ -21,7 +21,7 @@ const allTactics = [...new Set(data.example_use_cases.flatMap((uc: any) => uc.ta
 const allTags = [...new Set(data.example_use_cases.flatMap((uc: any) => uc.tags))];
 ---
 
-<BaseLayout title={data.name} description={data.short_description}>
+<BaseLayout title={data.name} description={data.short_description} type="article">
   <div class="mb-6">
     <a href={url('/binaries/')} class="text-text-secondary hover:text-text-primary text-sm">&larr; All Binaries</a>
   </div>


### PR DESCRIPTION
## Summary
- Add `@astrojs/sitemap` integration for automatic sitemap generation
- Add Open Graph and Twitter Card meta tags to all pages via `BaseLayout.astro`
- Add canonical URLs, JSON-LD structured data (`WebSite` schema), and `robots.txt`
- Add apple-touch-icon for iOS bookmark support
- Set `og:type="article"` on individual LOOBin pages for better search engine classification

## Test plan
- [ ] Verify build succeeds (`npm run build` in `web/`)
- [ ] Check `sitemap-index.xml` and `sitemap-0.xml` are generated in build output
- [ ] Verify `robots.txt` is present in build output with correct sitemap URL
- [ ] Inspect HTML output for OG, Twitter, canonical, and JSON-LD tags
- [ ] Test social sharing preview with a validator (e.g., https://www.opengraph.xyz/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)