### PR TITLE
Harden PyLOOBins code correctness and CI

### DIFF
--- a/.github/workflows/validate_loobins.yml
+++ b/.github/workflows/validate_loobins.yml
@@ -7,27 +7,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8", "3.10", "3.12"]
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v35
-      with:
-          files: LOOBins/*.{yml,yaml}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install pyloobins from local source
       run: |
         python -m pip install --upgrade pip
-        pip install pyloobins
-    - name: Checking the YAML files with pyloobins
+        pip install .
+    - name: Validate the full LOOBins corpus with local pyloobins
       run: |
-        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-          pyloobins validate --path $file
+        status=0
+        for file in LOOBins/*.yml; do
+          pyloobins validate --path "$file" || status=1
         done
+        exit $status

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "click>=8.1.3,<9",
     "jinja2>=3.1.2,<4",
     "stix2>=3.0.1,<4",
-    "polyfactory>=2.18.0,<3",
 ]
 
 [project.urls]
@@ -34,6 +33,7 @@ dev = [
     "pytest>=7.3.1",
     "tox>=4.5.1",
     "isort>=5.12.0",
+    "polyfactory>=2.18.0,<3",
 ]
 
 [build-system]
@@ -62,6 +62,7 @@ legacy_tox_ini = """
   wheel_build_env = .pkg
   deps =
       pytest>=6
+      polyfactory>=2.18.0,<3
   commands =
       pytest {tty:--color=yes} {posargs}
 """

--- a/src/pyloobins/cli.py
+++ b/src/pyloobins/cli.py
@@ -51,7 +51,9 @@ def create(name: str, path: str) -> None:
         )
     file_path = path if path and os.path.exists(path) else "./"
     with open(
-        file=f"{file_path}{file_name}.yml", mode="w", encoding="utf-8"
+        file=os.path.join(file_path, f"{file_name}.yml"),
+        mode="w",
+        encoding="utf-8",
     ) as out_file:
         out_file.write(template)
 
@@ -84,14 +86,14 @@ def get(name: str, path: str = "") -> None:
     "--path",
     type=str,
     required=False,
-    help="Enter the path where you would like to create the template YAML file.",
+    help="Enter the directory where you would like to write the STIX bundle file.",
     default=".",
 )
 @click.option(
     "--file-name",
     type=str,
     required=False,
-    help="Enter the path where you would like to create the template YAML file.",
+    help="Enter the file name for the exported STIX bundle.",
     default="loobins_stix.json",
 )
 def export_stix(file_name: str, path: str) -> None:
@@ -104,7 +106,7 @@ def export_stix(file_name: str, path: str) -> None:
             f"Creating the {file_name} file in the current directory."
         )
     file_path = path if path and os.path.exists(path) else "./"
-    with open(f"{file_path}/{file_name}", mode="w+", encoding="utf-8") as f:
+    with open(os.path.join(file_path, file_name), mode="w+", encoding="utf-8") as f:
         f.write(stix_bundle.to_stix_bundle().serialize(pretty=True))
 
 

--- a/src/pyloobins/util.py
+++ b/src/pyloobins/util.py
@@ -1,5 +1,7 @@
 """Utility functions that support the CLI and library"""
 
+from __future__ import annotations
+
 import pathlib
 from datetime import date
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,70 @@
+"""Tests for the pyloobins CLI commands."""
+
+import json
+
+from click.testing import CliRunner
+
+from pyloobins.cli import cli
+from pyloobins.util import make_template, normalize_file_name
+
+
+def test_validate_valid_file(tmp_path):
+    """A schema-conformant file validates and exits 0."""
+    yml = tmp_path / "valid.yml"
+    yml.write_text(make_template(name="TestBin").to_yaml(), encoding="utf-8")
+    result = CliRunner().invoke(cli, ["validate", "--path", str(yml)])
+    assert result.exit_code == 0
+    assert "is valid" in result.output
+
+
+def test_validate_invalid_file(tmp_path):
+    """A file missing required fields fails validation and exits 1."""
+    yml = tmp_path / "invalid.yml"
+    yml.write_text("name: OnlyName\n", encoding="utf-8")
+    result = CliRunner().invoke(cli, ["validate", "--path", str(yml)])
+    assert result.exit_code == 1
+    assert "NOT valid" in result.output
+
+
+def test_create_writes_file_without_trailing_slash(tmp_path):
+    """--path need not end in a slash (regression for the path-join fix)."""
+    result = CliRunner().invoke(
+        cli, ["create", "--name", "My Bin", "--path", str(tmp_path)]
+    )
+    assert result.exit_code == 0
+    expected = tmp_path / f"{normalize_file_name('My Bin')}.yml"
+    assert expected.exists()
+    # The written template round-trips through validation.
+    assert "name: My Bin" in expected.read_text(encoding="utf-8")
+
+
+def test_get_found(tmp_path):
+    """get returns the matching LOOBin as JSON."""
+    yml = tmp_path / "testbin.yml"
+    yml.write_text(make_template(name="TestBin").to_yaml(), encoding="utf-8")
+    result = CliRunner().invoke(
+        cli, ["get", "--name", "TestBin", "--path", str(tmp_path)]
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["name"] == "TestBin"
+
+
+def test_get_not_found(tmp_path):
+    """get reports when no LOOBin matches."""
+    result = CliRunner().invoke(
+        cli, ["get", "--name", "Nonexistent", "--path", str(tmp_path)]
+    )
+    assert "No LOOBin found" in result.output
+
+
+def test_export_stix_writes_bundle(tmp_path):
+    """export-stix writes a parseable STIX bundle to the chosen path."""
+    result = CliRunner().invoke(
+        cli, ["export-stix", "--path", str(tmp_path), "--file-name", "out.json"]
+    )
+    assert result.exit_code == 0
+    out = tmp_path / "out.json"
+    assert out.exists()
+    bundle = json.loads(out.read_text(encoding="utf-8"))
+    assert bundle["type"] == "bundle"

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,27 @@
+"""Validate every committed LOOBin YAML file against the schema.
+
+This guards the whole corpus (not just files changed in a PR) so a
+schema/model change that breaks a pre-existing entry fails fast.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pyloobins.util import validate_loobin
+
+LOOBINS_DIR = Path(__file__).resolve().parents[1] / "LOOBins"
+LOOBIN_FILES = sorted(LOOBINS_DIR.glob("*.yml"))
+
+
+def test_loobins_dir_is_populated():
+    """Guard against the glob silently matching nothing."""
+    assert LOOBIN_FILES, f"No LOOBin YAML files found in {LOOBINS_DIR}"
+
+
+@pytest.mark.parametrize("yml_file", LOOBIN_FILES, ids=lambda p: p.name)
+def test_loobin_file_validates(yml_file):
+    """Each committed LOOBin YAML file must satisfy the schema."""
+    assert validate_loobin(
+        yml_path=str(yml_file)
+    ), f"{yml_file.name} failed schema validation"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,14 +1,19 @@
-from pyloobins.models import Detection, ExampleUseCase, LOOBin, LOOBinsGroup, Resource
 from polyfactory.factories.pydantic_factory import ModelFactory
+
+from pyloobins.models import Detection, ExampleUseCase, LOOBin, LOOBinsGroup, Resource
+
 
 class DetectionFactory(ModelFactory[Detection]):
     __model__ = Detection
 
+
 class ExampleUseCaseFactory(ModelFactory[ExampleUseCase]):
     __model__ = ExampleUseCase
 
+
 class ResourceFactory(ModelFactory[Resource]):
     __model__ = Resource
+
 
 class LOOBinFactory(ModelFactory[LOOBin]):
     __model__ = LOOBin

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,29 +1,97 @@
 """Test the models in the pyloobins.models module."""
 
-from pyloobins.models import Detection, ExampleUseCase, LOOBin, LOOBinsGroup, Resource
-from tests.test_data import DetectionFactory, ResourceFactory, LOOBinFactory, ExampleUseCaseFactory
+from datetime import date
+
+from pyloobins.models import (
+    Detection,
+    ExampleUseCase,
+    LOOBin,
+    LOOBinsGroup,
+    Resource,
+)
+from tests.test_data import (
+    DetectionFactory,
+    ExampleUseCaseFactory,
+    LOOBinFactory,
+    ResourceFactory,
+)
+
+
+def _sample_loobin() -> LOOBin:
+    """Build a deterministic LOOBin for behavioral assertions."""
+    return LOOBin(
+        name="sample",
+        author="tester",
+        short_description="short",
+        full_description="full",
+        created=date(2024, 1, 1),
+        example_use_cases=[
+            ExampleUseCase(
+                name="uc1",
+                description="d1",
+                tactics=["Discovery", "Execution"],
+                tags=["a", "b"],
+            ),
+            ExampleUseCase(
+                name="uc2",
+                description="d2",
+                tactics=["Execution", "Persistence"],
+                tags=["b", "c"],
+            ),
+        ],
+        paths=["/usr/bin/sample"],
+        detections=[
+            Detection(name="no detection", url="N/A"),
+            Detection(name="Sigma", url="https://example.com"),
+        ],
+    )
 
 
 def test_detection():
-    """Test the AttackTactics model."""
-    assert type(DetectionFactory.build()) == Detection
+    """The Detection factory builds a Detection."""
+    assert isinstance(DetectionFactory.build(), Detection)
 
 
 def test_resource():
-    """Test the Resource model."""
-    assert type(ResourceFactory.build()) == Resource
+    """The Resource factory builds a Resource."""
+    assert isinstance(ResourceFactory.build(), Resource)
 
 
 def test_example_use_case():
-    """Test the ExampleUseCase model."""
-    assert type(ExampleUseCaseFactory.build()) == ExampleUseCase
+    """The ExampleUseCase factory builds an ExampleUseCase."""
+    assert isinstance(ExampleUseCaseFactory.build(), ExampleUseCase)
 
 
 def test_loobin():
-    """Test the LOOBin model."""
-    assert type(LOOBinFactory.build()) == LOOBin
+    """The LOOBin factory builds a LOOBin."""
+    assert isinstance(LOOBinFactory.build(), LOOBin)
 
 
 def test_loobin_group():
-    """Test the LOOBin group model."""
+    """A LOOBinsGroup can be built from a batch of LOOBins."""
     assert LOOBinsGroup(LOOBinFactory.batch(2))
+
+
+def test_combine_tactics_dedupes_preserving_order():
+    """combine_tactics unions use-case tactics, de-duped, in first-seen order."""
+    assert _sample_loobin().combine_tactics() == [
+        "Discovery",
+        "Execution",
+        "Persistence",
+    ]
+
+
+def test_combine_tags_dedupes_preserving_order():
+    """combine_tags unions use-case tags, de-duped, in first-seen order."""
+    assert _sample_loobin().combine_tags() == ["a", "b", "c"]
+
+
+def test_to_md_renders_sections_and_na_detection():
+    """to_md renders the core sections and handles the 'N/A' detection sentinel."""
+    md = _sample_loobin().to_md()
+    assert "# sample" in md
+    assert "/usr/bin/sample" in md
+    # A detection whose URL is "N/A" renders as plain text (no link).
+    assert "- no detection" in md
+    # A detection with a real URL renders as a Markdown link.
+    assert "[Sigma](https://example.com)" in md

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,11 @@
 """Tests for the pyloobins.util module."""
-import os
-from pathlib import Path
 
-from pyloobins.util import get_loobins, make_template, validate_loobin
+from pyloobins.util import (
+    get_loobins,
+    make_template,
+    normalize_file_name,
+    validate_loobin,
+)
 
 
 def test_get_loobins():
@@ -15,10 +18,13 @@ def test_make_template():
     assert make_template()
 
 
-def test_validate_loobin():
+def test_validate_loobin(tmp_path):
     """Test the validate_loobin function."""
-    test_file = Path("./tests/test.yml")
-    with open(test_file, "w", encoding="utf-8") as f:
-        f.write(make_template().to_yaml())
+    test_file = tmp_path / "test.yml"
+    test_file.write_text(make_template().to_yaml(), encoding="utf-8")
     assert validate_loobin(yml_path=str(test_file))
-    os.remove(test_file)
+
+
+def test_normalize_file_name():
+    """Names are lowercased and spaces become underscores."""
+    assert normalize_file_name("My Bin") == "my_bin"


### PR DESCRIPTION
Fixes several latent defects and strengthens the test/CI safety net:

- util.py: add `from __future__ import annotations` so the `list[LOOBin]`
  return annotation no longer crashes on import under Python 3.8 (the
  declared minimum, exercised by tox).
- pyproject.toml: move `polyfactory` from production deps to the dev group
  (it is test-only) and add it to tox `deps` so factories resolve there.
- cli.py: correct the copy-pasted `export-stix` help text and build output
  paths with `os.path.join` so `create`/`export-stix` no longer require a
  trailing slash on `--path`.
- tests: add full-corpus schema validation (every LOOBins/*.yml), CLI tests
  via CliRunner, and behavioral tests for combine_tactics/combine_tags/to_md;
  isolate test_util with tmp_path.
- validate_loobins.yml: install pyloobins from local source instead of PyPI,
  validate the full corpus (not just changed files), bump action versions,
  and test across Python 3.8/3.10/3.12.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpaPCpgTmmeVudU9w71wmG