### PR TITLE
Skip missing Python interpreters in tox run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ legacy_tox_ini = """
   env_list =
       py38,py39,py310,py311,py312
   minversion = 4.5.1
+  # Don't fail the whole run when a Python version in env_list isn't installed
+  # locally; CI still provides the full 3.8-3.12 matrix.
+  skip_missing_interpreters = true
 
   [testenv]
   description = run the tests with pytest


### PR DESCRIPTION
tox failed with 'could not find python interpreter matching any of the
specs py39' when Python 3.8/3.9 aren't installed locally. Set
skip_missing_interpreters = true so absent interpreters in env_list are
skipped rather than failing the whole run. CI still supplies the full
3.8-3.12 matrix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D18inGHxJ8BrH2BpGH2u94